### PR TITLE
Add separate executor and callback group

### DIFF
--- a/src/rviz_polygon_selection_tool.cpp
+++ b/src/rviz_polygon_selection_tool.cpp
@@ -58,9 +58,17 @@ void PolygonSelectionTool::onInitialize()
   executor_callback_group_ = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   executor_.add_callback_group(executor_callback_group_, node->get_node_base_interface());
 
+#ifdef QOS_REQUIRED_IN_SERVICE
+  rclcpp::QoS qos(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT, 1),
+                  rmw_qos_profile_services_default);
+  server_ = node->create_service<srv::GetSelection>(
+      "get_selection", std::bind(&PolygonSelectionTool::callback, this, std::placeholders::_1, std::placeholders::_2),
+      qos, executor_callback_group_);
+#else
   server_ = node->create_service<srv::GetSelection>(
       "get_selection", std::bind(&PolygonSelectionTool::callback, this, std::placeholders::_1, std::placeholders::_2),
       rmw_qos_profile_services_default, executor_callback_group_);
+#endif
 
   executor_thread_ = std::thread([&]() { executor_.spin(); });
 #else

--- a/src/rviz_polygon_selection_tool.cpp
+++ b/src/rviz_polygon_selection_tool.cpp
@@ -32,6 +32,11 @@ PolygonSelectionTool::PolygonSelectionTool() : rviz_common::Tool()
 
 PolygonSelectionTool::~PolygonSelectionTool()
 {
+#ifdef CALLBACK_GROUP_SUPPORTED
+  executor_.cancel();
+  executor_thread_.join();
+#endif
+
   // Remove materials
   Ogre::MaterialManager::getSingleton().remove(points_material_);
   Ogre::MaterialManager::getSingleton().remove(lines_material_);
@@ -48,8 +53,21 @@ PolygonSelectionTool::~PolygonSelectionTool()
 void PolygonSelectionTool::onInitialize()
 {
   rclcpp::Node::SharedPtr node = context_->getRosNodeAbstraction().lock()->get_raw_node();
+
+#ifdef CALLBACK_GROUP_SUPPORTED
+  executor_callback_group_ = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  executor_.add_callback_group(executor_callback_group_, node->get_node_base_interface());
+
+  server_ = node->create_service<srv::GetSelection>(
+      "get_selection", std::bind(&PolygonSelectionTool::callback, this, std::placeholders::_1, std::placeholders::_2),
+      rmw_qos_profile_services_default, executor_callback_group_);
+
+  executor_thread_ = std::thread([&]() { executor_.spin(); });
+#else
   server_ = node->create_service<srv::GetSelection>(
       "get_selection", std::bind(&PolygonSelectionTool::callback, this, std::placeholders::_1, std::placeholders::_2));
+#endif
+
   points_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("points_material");
   lines_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("lines_material");
 

--- a/src/rviz_polygon_selection_tool.h
+++ b/src/rviz_polygon_selection_tool.h
@@ -5,6 +5,12 @@
 #include <rviz_common/tool.hpp>
 #include <rclcpp/service.hpp>
 
+#include "version_check.hpp"
+#ifdef CALLBACK_GROUP_SUPPORTED
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <thread>
+#endif
+
 namespace rviz_rendering
 {
 class MaterialManager;
@@ -61,6 +67,12 @@ private:
   rviz_common::properties::BoolProperty* text_visibility_property_;
   rviz_common::properties::FloatProperty* text_size_property_;
   rviz_common::properties::FloatProperty* points_gap_size_property_;
+
+#ifdef CALLBACK_GROUP_SUPPORTED
+  std::thread executor_thread_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
+  rclcpp::CallbackGroup::SharedPtr executor_callback_group_;
+#endif
 
   rclcpp::Service<srv::GetSelection>::SharedPtr server_;
 

--- a/src/version_check.hpp
+++ b/src/version_check.hpp
@@ -2,7 +2,13 @@
 
 #if __has_include(<rclcpp/version.h>)
 #include <rclcpp/version.h>
+
 #if (RCLCPP_VERSION_MAJOR >= 5)
 #define CALLBACK_GROUP_SUPPORTED
 #endif
+
+#if (RCLCPP_VERSION_MAJOR >= 28)
+#define QOS_REQUIRED_IN_SERVICE
+#endif
+
 #endif

--- a/src/version_check.hpp
+++ b/src/version_check.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#if __has_include(<rclcpp/version.h>)
+#include <rclcpp/version.h>
+#if (RCLCPP_VERSION_MAJOR >= 5)
+#define CALLBACK_GROUP_SUPPORTED
+#endif
+#endif


### PR DESCRIPTION
This PR adds a separate executor and callback group to the tool such that service clients created by the Rviz node (e.g., in other tools, panels, etc.) can call this tool's service without causing deadlock