### PR TITLE
Render displays as overlay for better visibility

### DIFF
--- a/src/rviz_polygon_selection_tool.cpp
+++ b/src/rviz_polygon_selection_tool.cpp
@@ -77,7 +77,12 @@ void PolygonSelectionTool::onInitialize()
 #endif
 
   points_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("points_material");
+  points_material_->setDepthCheckEnabled(false);
+  points_material_->setDepthWriteEnabled(false);
+
   lines_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("lines_material");
+  lines_material_->setDepthCheckEnabled(false);
+  lines_material_->setDepthWriteEnabled(false);
 
   // Add the properties
   lasso_mode_property_ = new rviz_common::properties::BoolProperty(
@@ -131,10 +136,12 @@ void PolygonSelectionTool::newPolygon()
 
   // Add the points visualization
   Ogre::ManualObject* points = scene_manager_->createManualObject("points_" + std::to_string(index));
+  points->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
   points_node_->attachObject(points);
 
   // Add the lines visualization
   Ogre::ManualObject* lines = scene_manager_->createManualObject("lines_" + std::to_string(index));
+  lines->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
   lines_node_->attachObject(lines);
 
   // Add the text
@@ -143,6 +150,9 @@ void PolygonSelectionTool::newPolygon()
                                                Ogre::ColourValue::Blue);
   text->setVisible(false);
   text->setTextAlignment(rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_ABOVE);
+  text->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
+  text->getMaterial()->setDepthCheckEnabled(false);
+  text->getMaterial()->setDepthWriteEnabled(false);
 
   // Attach the text to a movable child scene node underneath the main text scene node
   text_node_->createChildSceneNode()->attachObject(text);

--- a/src/rviz_polygon_selection_tool.cpp
+++ b/src/rviz_polygon_selection_tool.cpp
@@ -77,12 +77,7 @@ void PolygonSelectionTool::onInitialize()
 #endif
 
   points_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("points_material");
-  points_material_->setDepthCheckEnabled(false);
-  points_material_->setDepthWriteEnabled(false);
-
   lines_material_ = rviz_rendering::MaterialManager::createMaterialWithLighting("lines_material");
-  lines_material_->setDepthCheckEnabled(false);
-  lines_material_->setDepthWriteEnabled(false);
 
   // Add the properties
   lasso_mode_property_ = new rviz_common::properties::BoolProperty(
@@ -112,6 +107,10 @@ void PolygonSelectionTool::onInitialize()
   points_gap_size_property_ = new rviz_common::properties::FloatProperty(
       "Point Generation Gap", 0.002, "Separation between adjacent points in a polygon (m)", getPropertyContainer());
 
+  render_as_overlay_property_ = new rviz_common::properties::BoolProperty(
+      "Render as Overlay", false, "Render the polygon points and lines on top of all other geometry",
+      getPropertyContainer(), SLOT(updateRenderAsOverlay()), this);
+
   points_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode("points");
   lines_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode("lines");
   text_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode("text");
@@ -136,12 +135,10 @@ void PolygonSelectionTool::newPolygon()
 
   // Add the points visualization
   Ogre::ManualObject* points = scene_manager_->createManualObject("points_" + std::to_string(index));
-  points->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
   points_node_->attachObject(points);
 
   // Add the lines visualization
   Ogre::ManualObject* lines = scene_manager_->createManualObject("lines_" + std::to_string(index));
-  lines->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
   lines_node_->attachObject(lines);
 
   // Add the text
@@ -150,9 +147,6 @@ void PolygonSelectionTool::newPolygon()
                                                Ogre::ColourValue::Blue);
   text->setVisible(false);
   text->setTextAlignment(rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_ABOVE);
-  text->setRenderQueueGroup(Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY);
-  text->getMaterial()->setDepthCheckEnabled(false);
-  text->getMaterial()->setDepthWriteEnabled(false);
 
   // Attach the text to a movable child scene node underneath the main text scene node
   text_node_->createChildSceneNode()->attachObject(text);
@@ -162,6 +156,7 @@ void PolygonSelectionTool::newPolygon()
   updatePointsColor();
   updateLinesColor();
   updateTextSize();
+  updateRenderAsOverlay();
 }
 
 void PolygonSelectionTool::removeDisplays()
@@ -346,6 +341,54 @@ void PolygonSelectionTool::updateText()
   text_pos /= static_cast<Ogre::Real>(points_.back().size());
 
   last_child_scene->setPosition(text_pos);
+}
+
+void PolygonSelectionTool::updateRenderAsOverlay()
+{
+  const bool render_as_overlay = render_as_overlay_property_->getBool();
+  Ogre::RenderQueueGroupID render_id =
+      render_as_overlay ? Ogre::RenderQueueGroupID::RENDER_QUEUE_OVERLAY : Ogre::RenderQueueGroupID::RENDER_QUEUE_MAIN;
+
+  // Lines
+  lines_material_->setDepthCheckEnabled(!render_as_overlay);
+  lines_material_->setDepthWriteEnabled(!render_as_overlay);
+  for (auto object : lines_node_->getAttachedObjects())
+  {
+    auto lines = dynamic_cast<Ogre::ManualObject*>(object);
+    if (!lines)
+      continue;
+    lines->setRenderQueueGroup(render_id);
+  }
+
+  // Points
+  points_material_->setDepthCheckEnabled(!render_as_overlay);
+  points_material_->setDepthWriteEnabled(!render_as_overlay);
+  for (auto object : points_node_->getAttachedObjects())
+  {
+    auto points = dynamic_cast<Ogre::ManualObject*>(object);
+    if (!points)
+      continue;
+    points->setRenderQueueGroup(render_id);
+  }
+
+  // Text
+  for (Ogre::Node* child : text_node_->getChildren())
+  {
+    auto scene_node = dynamic_cast<Ogre::SceneNode*>(child);
+    if (!scene_node)
+      continue;
+
+    for (auto object : scene_node->getAttachedObjects())
+    {
+      auto text = dynamic_cast<rviz_rendering::MovableText*>(object);
+      if (!text)
+        continue;
+
+      text->setRenderQueueGroup(render_id);
+      text->getMaterial()->setDepthCheckEnabled(!render_as_overlay);
+      text->getMaterial()->setDepthWriteEnabled(!render_as_overlay);
+    }
+  }
 }
 
 void PolygonSelectionTool::callback(const srv::GetSelection::Request::SharedPtr /*req*/,

--- a/src/rviz_polygon_selection_tool.h
+++ b/src/rviz_polygon_selection_tool.h
@@ -53,6 +53,7 @@ public Q_SLOTS:
   void updateVisual();
   void updateTextVisibility();
   void updateTextSize();
+  void updateRenderAsOverlay();
 
 private:
   void callback(const srv::GetSelection::Request::SharedPtr, const srv::GetSelection::Response::SharedPtr res);
@@ -67,6 +68,7 @@ private:
   rviz_common::properties::BoolProperty* text_visibility_property_;
   rviz_common::properties::FloatProperty* text_size_property_;
   rviz_common::properties::FloatProperty* points_gap_size_property_;
+  rviz_common::properties::BoolProperty* render_as_overlay_property_;
 
 #ifdef CALLBACK_GROUP_SUPPORTED
   std::thread executor_thread_;


### PR DESCRIPTION
Often the lines drawn with this tool "weave" in and out of the geometry they are drawn on top of due to the positions of the points selected and the depth rendering order. This makes it somewhat difficult to see the drawn polygons. This PR changes the rendering properties of the materials and displays in this tool to make them appear as overlays (i.e., on top of all geometry) for better visibility

To-do:
- [x] Consider making this overlay rendering optional with a tool property