### PR TITLE
Support compatibility with Rolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(pluginlib REQUIRED)
 
+find_package(rviz_default_plugins REQUIRED)
+find_package(resource_retriever REQUIRED)
+
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
   "srv/GetSelection.srv"
@@ -45,7 +48,9 @@ target_link_libraries(
   PUBLIC ${msgs_target}
          pluginlib::pluginlib
          rviz_common::rviz_common
-         rviz_rendering::rviz_rendering)
+         rviz_rendering::rviz_rendering
+         resource_retriever::resource_retriever
+         rviz_default_plugins::rviz_default_plugins)
 
 # Install the library
 install(TARGETS ${PROJECT_NAME}_plugin EXPORT ${PROJECT_NAME}-targets DESTINATION lib)

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,9 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <depend>geometry_msgs</depend>
+  <depend>resource_retriever</depend>
   <depend>rviz_common</depend>
+  <depend>rviz_default_plugins</depend>
   <depend>rviz_rendering</depend>
   <depend>pluginlib</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/src/mesh_polygon_selection_tool.cpp
+++ b/src/mesh_polygon_selection_tool.cpp
@@ -13,6 +13,57 @@
 const static std::string COLOR_NAME = "mesh_cursor_tool_color";
 const static std::string DEFAULT_MESH_RESOURCE = "package://rviz_polygon_selection_tool/resources/default.stl";
 
+#if !defined(RCLCPP_VERSION_MAJOR) || (RCLCPP_VERSION_MAJOR <= 28)
+Ogre::MeshPtr loadMesh(const std::string& resource, const rviz_common::DisplayContext*)
+{
+  // Attempt to load the mesh
+  Ogre::MeshPtr mesh = rviz_rendering::loadMeshFromResource(resource);
+  if (!mesh)
+  {
+    // ROS_WARN("Loading default mesh...");
+
+    // Load a default mesh
+    mesh = rviz_rendering::loadMeshFromResource(DEFAULT_MESH_RESOURCE);
+  }
+
+  return mesh;
+}
+#else
+#include <rviz_default_plugins/ros_resource_retriever.hpp>
+#include <resource_retriever/retriever.hpp>
+#include <rviz_common/display_context.hpp>
+
+Ogre::MeshPtr loadMesh(const std::string& resource, rviz_common::DisplayContext* context)
+{
+  // Attempt to load the mesh
+  resource_retriever::RetrieverVec plugins;
+  if (context != nullptr)
+  {
+    std::shared_ptr node_ptr = context->getRosNodeAbstraction().lock();
+    if (node_ptr != nullptr)
+    {
+      plugins.push_back(std::make_shared<RosResourceRetriever>(context->getRosNodeAbstraction()));
+    }
+  }
+  for (const auto& plugin : resource_retriever::default_plugins())
+  {
+    plugins.push_back(plugin);
+  }
+  resource_retriever::Retriever ret = resource_retriever::Retriever(plugins);
+
+  Ogre::MeshPtr mesh = rviz_rendering::loadMeshFromResource(&ret, resource);
+  if (!mesh)
+  {
+    // ROS_WARN("Loading default mesh...");
+
+    // Load a default mesh
+    mesh = rviz_rendering::loadMeshFromResource(&ret, DEFAULT_MESH_RESOURCE);
+  }
+
+  return mesh;
+}
+#endif
+
 namespace rviz_polygon_selection_tool
 {
 MeshPolygonSelectionTool::MeshPolygonSelectionTool() : PolygonSelectionTool()
@@ -38,17 +89,7 @@ MeshPolygonSelectionTool::~MeshPolygonSelectionTool()
 
 Ogre::MovableObject* MeshPolygonSelectionTool::createToolVisualization()
 {
-  // Attempt to load the mesh
-  Ogre::MeshPtr mesh = rviz_rendering::loadMeshFromResource(mesh_file_->getStdString());
-  if (!mesh)
-  {
-    // ROS_WARN("Loading default mesh...");
-
-    // Load a default mesh
-    mesh = rviz_rendering::loadMeshFromResource(DEFAULT_MESH_RESOURCE);
-  }
-
-  Ogre::Entity* entity = scene_manager_->createEntity(mesh);
+  Ogre::Entity* entity = scene_manager_->createEntity(loadMesh(mesh_file_->getStdString(), context_));
   for (unsigned i = 0; i < entity->getNumSubEntities(); ++i)
   {
     Ogre::SubEntity* sub = entity->getSubEntity(i);


### PR DESCRIPTION
The API for loading a mesh from resource changed in `rviz_rendering`. This PR updates the usage of this API to support Humble, Jazzy, and Rolling